### PR TITLE
Bumped the cargo-maven2-plugin version

### DIFF
--- a/maven-cargo/pom.xml
+++ b/maven-cargo/pom.xml
@@ -81,7 +81,7 @@
       <plugin>
         <groupId>org.codehaus.cargo</groupId>
         <artifactId>cargo-maven2-plugin</artifactId>
-        <version>1.7.3</version>
+        <version>1.7.15</version>
         <configuration>
           <container>
             <containerId>jetty9x</containerId>


### PR DESCRIPTION
Moved to a newer version as the old version does not build since Maven Central moved to https.